### PR TITLE
fix: error en bycript

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic[email]==2.5.0
 PyJWT==2.8.0
 passlib[bcrypt]==1.7.4
 python-multipart==0.0.6
+bcrypt==4.0.1


### PR DESCRIPTION
He rastreado un error generado por bycript 5.0.0 en el que presenta porblemas de compatibilidad con passlib. He agregado a requirements.txt la version de bycript correcta para impedir incompatibilidades futuras